### PR TITLE
fix checkbox being not visible

### DIFF
--- a/modules/subjects/src/app/shared/visiting-popover/visiting-popover.component.html
+++ b/modules/subjects/src/app/shared/visiting-popover/visiting-popover.component.html
@@ -45,7 +45,7 @@
             {{ 'comment' | translate: 'Комментарий' }}</mat-header-cell
           >
           <mat-cell *matCellDef="let element">
-            <mat-form-field style="margin-right: 20px">
+            <mat-form-field style="margin-right: 20px; width: 110px">
               <input name="comment" matInput [(ngModel)]="element.comment" />
             </mat-form-field>
             <mat-checkbox


### PR DESCRIPTION
the checkbox was not visible because the width of `mat-form-field-infix` was set to 180px by default, pushing checkbox out of window.