### PR TITLE
Fix shedule creator

### DIFF
--- a/api/Application.Infrastructure/ScheduleManagement/ScheduleManagementService.cs
+++ b/api/Application.Infrastructure/ScheduleManagement/ScheduleManagementService.cs
@@ -274,20 +274,33 @@ namespace Application.Infrastructure.ScheduleManagement
 			{
 				if (classType == ClassType.Lecture)
                 {
-					return LectureScheduleToModel(repositoriesContainer.RepositoryFor<LecturesScheduleVisiting>().GetBy(new Query<LecturesScheduleVisiting>(x => x.Id == scheduleId)
-					.Include(x => x.Subject.LecturesScheduleVisitings.Select(x => x.Notes))));
+					return LectureScheduleToModel(
+						repositoriesContainer
+						.RepositoryFor<LecturesScheduleVisiting>()
+						.GetBy(new Query<LecturesScheduleVisiting>(x => x.Id == scheduleId)
+                        .Include(x => x.Lecturer)
+						.Include(x => x.Subject.LecturesScheduleVisitings.Select(x => x.Notes))));
 
 				} else if (classType == ClassType.Lab)
                 {
-					return LabScheduleToModel(repositoriesContainer.RepositoryFor<ScheduleProtectionLabs>().GetBy(new Query<ScheduleProtectionLabs>(x => x.Id == scheduleId)
-					.Include(x => x.Subject.ScheduleProtectionLabs.Select(x => x.Notes))
-					.Include(x => x.Subject.SubjectGroups.Select(sg => sg.Group))
-					.Include(x => x.Subject.SubjectGroups.Select(sg => sg.SubGroups))));
+					return LabScheduleToModel(
+						repositoriesContainer
+						.RepositoryFor<ScheduleProtectionLabs>()
+						.GetBy(new Query<ScheduleProtectionLabs>(x => x.Id == scheduleId)
+                        .Include(x => x.Lecturer)
+                        .Include(x => x.Subject.ScheduleProtectionLabs.Select(x => x.Notes))
+						.Include(x => x.Subject.SubjectGroups.Select(sg => sg.Group))
+						.Include(x => x.Subject.SubjectGroups.Select(sg => sg.SubGroups))));
+
 				} else if (ClassType.Practical == classType)
                 {
-					return PracticalScheduleToModel(repositoriesContainer.RepositoryFor<ScheduleProtectionPractical>().GetBy(new Query<ScheduleProtectionPractical>(x => x.Id == scheduleId)
-					.Include(x => x.Subject.ScheduleProtectionPracticals.Select(x => x.Notes))
-					.Include(x => x.Subject.SubjectGroups.Select(sg => sg.Group))));
+					return PracticalScheduleToModel(
+						repositoriesContainer
+						.RepositoryFor<ScheduleProtectionPractical>()
+						.GetBy(new Query<ScheduleProtectionPractical>(x => x.Id == scheduleId)
+                        .Include(x => x.Lecturer)
+                        .Include(x => x.Subject.ScheduleProtectionPracticals.Select(x => x.Notes))
+						.Include(x => x.Subject.SubjectGroups.Select(sg => sg.Group))));
 				}
 				return null;
 			}

--- a/modules/schedule/src/app/modal/create-lesson/create-lesson.component.ts
+++ b/modules/schedule/src/app/modal/create-lesson/create-lesson.component.ts
@@ -611,9 +611,22 @@ export class CreateLessonComponent implements OnInit {
     })
     this.lessonservice.getJoinedLector(event.value).subscribe((re) => {
       this.teachers = re
+
+      const currentLector = re.find(t => t.LectorId === +this.user.id);
+
+      if (currentLector) {
+        this.formGroup.controls.teacher.setValue(currentLector.LectorId);
+        this.lesson.Teacher = currentLector;
+        } else {
+          this.formGroup.controls.teacher.reset();
+        }
+
+      this.formGroup.controls.teacher.enable()
     })
-    this.formGroup.controls.teacher.enable()
-    this.formGroup.controls.teacher.setValue(+this.user.id)
+
+    this.lessonservice.getLessonTypes(subjectId).subscribe((types) => {
+      this.lessonTypesFull = types;
+    });
   }
 
   teacherChange(event): void {

--- a/modules/schedule/src/app/service/lesson.service.ts
+++ b/modules/schedule/src/app/service/lesson.service.ts
@@ -73,18 +73,19 @@ export class LessonService {
     )
   }
 
-  saveLab(Lab: any, dateLab: string): Observable<any> {
+  saveLab(lab: any, dateLab: string): Observable<any> {
     return this.http.post<any>(
       '/Services/Schedule/ScheduleService.svc/SaveDateLab',
       {
-        id: Lab.Id,
-        subjectId: Lab.SubjectId,
+        id: lab.Id,
+        subjectId: lab.SubjectId,
         date: dateLab,
-        startTime: Lab.Start,
-        endTime: Lab.End,
-        building: Lab.Building,
-        audience: Lab.Audience,
-        subGroupId: Lab.SubGroupId,
+        startTime: lab.Start,
+        endTime: lab.End,
+        building: lab.Building,
+        audience: lab.Audience,
+        subGroupId: lab.SubGroupId,
+        lecturerId: lab.Teacher.LectorId
       }
     )
   }
@@ -108,6 +109,7 @@ export class LessonService {
         building: pract.Building,
         audience: pract.Audience,
         groupId: pract.GroupId,
+        lecturerId: pract.Teacher.LectorId
       }
     )
   }
@@ -130,6 +132,7 @@ export class LessonService {
         endTime: lect.End,
         building: lect.Building,
         audience: lect.Audience,
+        lecturerId: lect.Teacher.LectorId
       }
     )
   }


### PR DESCRIPTION
Previously, when creating a new lesson, the schedule incorrectly assigned the subject creator as the lecturer.
Now, the system properly assigns the lecturer selected in the form — or automatically sets the current user if they are a lecturer for the selected subject.