### PR TITLE
Fix lesson audience not displayed

### DIFF
--- a/modules/subjects/src/app/shared/visit-date-popover/visit-date-popover.component.html
+++ b/modules/subjects/src/app/shared/visit-date-popover/visit-date-popover.component.html
@@ -195,6 +195,15 @@
                     {{ day.StartTime }}-{{ day.EndTime }}
                   </mat-hint>
                 </td>
+                <td class="mdc-data-table__cell">
+                  <mat-hint
+                    *ngIf="day.Audience && day.Building"
+                    style="font-size: 12px"
+                  >
+                    {{ 'date.building' | translate: 'к' }}.{{ day.Building }},
+                    {{ 'date.audience' | translate: 'а' }}.{{ day.Audience }}
+                  </mat-hint>
+                </td>
                 <td class="mdc-data-table__cell visit-date__table-action">
                   <button
                     mat-icon-button


### PR DESCRIPTION
This PR adds proper display of the Building and Audience fields for lectures, practical lessons, and lab sessions.

Previously, the API returned these values, but the UI did not render them.
The display logic is now aligned with the course consultation component.